### PR TITLE
new datasets

### DIFF
--- a/raw_data/0390/0390_gradient.txt
+++ b/raw_data/0390/0390_gradient.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f243901c36cbb73e3d9a00513ecc67021b20989298c255502fa0eb285be80a93
+size 153

--- a/raw_data/0390/0390_info.txt
+++ b/raw_data/0390/0390_info.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:305755d52cf36212de390c80fc43220177ba6bf8a84fa12a2da4e03161541f1c
+size 135

--- a/raw_data/0390/0390_metadata.txt
+++ b/raw_data/0390/0390_metadata.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8643925ed57d5884a92924e48af061c6642e7e5b7bceae9a07070b282ba64f7a
+size 3665

--- a/raw_data/0390/0390_rtdata.txt
+++ b/raw_data/0390/0390_rtdata.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e4780a4ba2709d98769b43af827c39453a49458d7cfa1dab338c98b52eb6551
+size 3713019

--- a/raw_data/0391/0391_gradient.txt
+++ b/raw_data/0391/0391_gradient.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f243901c36cbb73e3d9a00513ecc67021b20989298c255502fa0eb285be80a93
+size 153

--- a/raw_data/0391/0391_info.txt
+++ b/raw_data/0391/0391_info.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:789fafb54c182c8939423078343b14b1efb24345806796d0901ea8974cfb14a9
+size 135

--- a/raw_data/0391/0391_metadata.txt
+++ b/raw_data/0391/0391_metadata.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6c8dfba2a2ac283a855650b3c43354cd6465281775975cfcccf8a1dbd48b3a2
+size 3665

--- a/raw_data/0391/0391_rtdata.txt
+++ b/raw_data/0391/0391_rtdata.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4925ff762d2c7a11765dc416330c8f15ec4562ffcc5e991bb038e6e22f717867
+size 4191058


### PR DESCRIPTION
Compounds were automatically annotated by MZmine and a compound table. Those annotated compounds were exported in the RepoRT format directly with MZmine. Multipe RTs for a compound are possible (if the same m/z occurred multiple times within one injection). This might be for multiple adducts and isomers